### PR TITLE
fix: `gen`を`generate`にリネーム (Rust 2024対応)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,7 @@ fn main() {
     let mut rng = rand::thread_rng();
     let generator = PasswordGenerator::new(password_length, weights, &args.symbol_sets);
 
-    match generator.gen(&mut rng) {
+    match generator.generate(&mut rng) {
         Ok(password) => println!("{}", password),
         Err(e) => {
             eprintln!("Error: {}", e);

--- a/src/password_generator.rs
+++ b/src/password_generator.rs
@@ -35,7 +35,7 @@ impl PasswordGenerator {
         }
     }
 
-    pub fn gen(&self, rng: &mut ThreadRng) -> Result<String, String> {
+    pub fn generate(&self, rng: &mut ThreadRng) -> Result<String, String> {
         let mut password = self.gen_minimum_password(rng);
 
         if self.length < password.len() {
@@ -88,7 +88,7 @@ mod tests {
         let mut rng = rand::thread_rng();
         let password_generator = PasswordGenerator::new(10, vec![1, 1, 1, 1], "!@#$%^&*()");
 
-        assert_eq!(password_generator.gen(&mut rng).unwrap().len(), 10);
+        assert_eq!(password_generator.generate(&mut rng).unwrap().len(), 10);
     }
 
     #[test]
@@ -96,6 +96,6 @@ mod tests {
         let mut rng = rand::thread_rng();
         let password_generator = PasswordGenerator::new(3, vec![1, 1, 1, 1], "!@#$%^&*()");
 
-        assert!(password_generator.gen(&mut rng).is_err());
+        assert!(password_generator.generate(&mut rng).is_err());
     }
 }


### PR DESCRIPTION
## Summary
- Rust Edition 2024では`gen`が予約キーワードになったため、関数名を`generate`に変更

## Test plan
- [ ] CI通過確認

🤖 Generated with [Claude Code](https://claude.ai/claude-code)